### PR TITLE
[PHYSICS] Use CMB-frame redshift (z_cmb) for host galaxies, not heliocentric

### DIFF
--- a/master_thesis_code/galaxy_catalogue/handler.py
+++ b/master_thesis_code/galaxy_catalogue/handler.py
@@ -111,9 +111,18 @@ class HostGalaxy:
 
 
 class CatalogueColumns(Enum):
+    # NB: entries MUST stay in ascending column-value order (pandas read_csv applies
+    # `names` to the `usecols` columns in ascending file order in parse_to_reduced_catalog).
     RIGHT_ASCENSION = 8  # in deg
     DECLINATION = 9  # in deg
-    REDSHIFT = 27
+    # CMB-frame redshift z_cmb (GLADE+ 0-based col 28). Previously col 27 (z_helio,
+    # heliocentric): feeding the heliocentric value into d_L(z; H0) left the solar-motion
+    # dipole (v_sun ~ 369.8 km/s) uncorrected in cz = H0*d_L — a coherent H0 systematic
+    # (per-event up to +/-2.47% at z~0.05; ~+0.15% net over the detected sample). z_cmb
+    # removes the solar dipole and, where GLADE+ flags it (col 29 == 1), is additionally
+    # peculiar-velocity corrected, with the PV-correction error in col 30 (added in
+    # quadrature below). Ref: Dálya et al. 2022, arXiv:2110.06184. See issue #15.
+    REDSHIFT = 28
     REDSHIFT_PECULIAR_VELOCITY_ERROR = 30
     REDSHIFT_MEASUREMENT_ERROR = 31
     REDSHIFT_FLAG = 34  # flag whether redshift is measured or estimated from distance


### PR DESCRIPTION
## What
Switch the GLADE+ host redshift from the **heliocentric** column (0-based 27, `z_helio`) to the **CMB-frame** column (0-based 28, `z_cmb`).

```diff
- REDSHIFT = 27   # z_helio
+ REDSHIFT = 28   # z_cmb
```

## Why
Feeding the heliocentric redshift into `d_L(z; H0)` left the solar-motion dipole (v_sun ≈ 369.8 km/s) uncorrected in `cz = H0·d_L` — a coherent, direction-dependent H0 systematic. `z_cmb` removes the solar dipole and, where GLADE+ flags it (col 29 == 1), is additionally peculiar-velocity corrected, with the PV-correction error already added in quadrature via col 30 (which now consistently describes an applied correction, rather than inflating the error of a correction that was never made).

## Impact (quantified, detected sample N=3375)
- Per-event worst case at z≈0.05: **±2.47%** in H0.
- Ensemble **net +0.15%** (the solar dipole largely sky-averages, ⟨cos θ_apex⟩ = +0.0245).
- Orthogonal to the H0 railing (which reproduces in a no-sky closure).

## Validation
- Column identities verified against Dálya et al. 2022 (arXiv:2110.06184) and the GLADE+ website, and **empirically** on `GLADE+.txt` (cols 27 vs 28 differ by the frame correction).
- Enum **ascending-order invariant preserved** (28 < 30), so the `usecols`/`names` alignment in `parse_to_reduced_catalog` is unchanged.
- No unit test hardcodes the column; CI runs the full lint/type/test gate.

## Note
The reduced catalogue (`reduced_galaxy_catalogue.csv`, gitignored) must be **regenerated from `GLADE+.txt`** for this to take effect in a run.

Closes #15. Follow-up: #16 (full host peculiar-velocity treatment). Full analysis: `.planning/derivation-photoz-incatalog/FRAME-SYSTEMATIC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVy21xcXo6rrEjwKSTTQ6e