### PR TITLE
[PHYSICS] Population-derived d_L pre-screen (fix #19) + Phase-2 campaign prep runbook

### DIFF
--- a/.planning/CAMPAIGN-PREP-PHASE2.md
+++ b/.planning/CAMPAIGN-PREP-PHASE2.md
@@ -16,13 +16,22 @@ the campaign. Owner: Jasper. Status legend: ☐ open · ☑ done · ⏳ blocked-
 
 ## 1. Blockers found during prep (fix BEFORE submitting the campaign)
 
-- ☐ **[HIGH — issue #19] `LUMINOSITY_DISTANCE_PRESCREEN_GPC = 2.0` is stale.**
-  Calibrated on retired pre-dt² injection data ("no detectable EMRI beyond 1.66 Gpc");
-  at physical SNR the horizon is z ≲ 1.5 (d_L ~ 11 Gpc). Running the campaign with it
-  silently truncates the detectable population (DEBUG-level log only).
-  Fix via `/physics-change`: derive from the M1 rate model's z_max at the smallest
-  grid h (× margin), or minimally bump to ≳ 16 Gpc and re-measure from the first
-  post-fix injection pool. **Do not submit the campaign before this lands.**
+- ☑ **[HIGH — issue #19] stale d_L pre-screen FIXED** (2026-07-02, `/physics-change`,
+  user-approved): `luminosity_distance_prescreen_gpc(z_max, h)` = 1.05 × d_L(rate-model
+  z_max; runtime h), computed once per run; WARNING on hit. Worse than reported: the old
+  2.0 Gpc cutoff was already inside the z ≤ 0.5 host-draw volume (d_L(0.5)=2.74 Gpc).
+  ☐ remaining: re-measure `PRESCREEN_DL_MARGIN` (placeholder 1.05) on post-dt² injection
+  data — same smoke run as the SNR-factor check below; issue #19 stays open for this.
+- ☐ **[DESIGN — decide before submit] `HOST_DRAW_Z_MAX = 0.5` is horizon-stale too.**
+  Its justification comment ("detection horizon z ≈ 0.18, so z < 0.5 is safely beyond →
+  truncation EXACT, p_det = 0 beyond") is pre-dt² reasoning; at physical SNR, p_det > 0
+  well beyond z = 0.5, so the z-cut now truncates *detectable* population. The sign-off
+  expects the campaign population to deepen to z ≲ 1.5 — that requires raising
+  HOST_DRAW_Z_MAX with GLADE completeness machinery beyond z = 0.5 (becomes binding) and
+  `GALAXY_CATALOG_REDSHIFT_UPPER_LIMIT = 0.55` alongside. Sim+inference use the cut
+  consistently, so this is a population-scope *decision*, not a silent bug — but the
+  campaign's science reach (event yield, forecast depth) hinges on it. Needs its own
+  issue + user decision + `/physics-change`.
 - ☐ **`PRE_SCREEN_SNR_FACTOR = 0.3` empirical re-check** (sign-off campaign-time action).
   Ratio-based, survives the dt² rescaling in principle, but the false-negative rate must
   be re-measured at the new depth (longer, more-redshifted waveforms): in the smoke run,

--- a/.planning/CAMPAIGN-PREP-PHASE2.md
+++ b/.planning/CAMPAIGN-PREP-PHASE2.md
@@ -1,0 +1,85 @@
+# Phase-2 Multi-Seed Production Campaign — Prep Runbook (2026-07-02)
+
+Derived from `.planning/gate/GATE_SIGNOFF.md` (gate PASSED, campaign unlocked) and the
+approved publication roadmap. This is the single checklist to run down before and during
+the campaign. Owner: Jasper. Status legend: ☐ open · ☑ done · ⏳ blocked-on.
+
+## 0. State at prep time
+
+- ☑ Gate G1–G11 signed off; PR #18 **merged to main** 2026-07-02 16:45Z (merge incl. the
+  docs-CI docstring fix `e283354` + G4b CHANGELOG/CLAUDE.md entries).
+- ⏳ seed600 full-grid confirmation (eval `5698617` + combine `5698618`) still queued;
+  partition widened in place to `cpu,cpu_il` (no cancel — priority-age preserved;
+  `cpu_il` jupyter reservation lifts weekdays 20:00). Retrieval recipe:
+  `.planning/HANDOFF-DERAIL-CLUSTER-CONFIRM-20260702.md` §"When the combine COMPLETES".
+  Expected: peaked ~0.73. Paper A slot marked RESULT PENDING.
+
+## 1. Blockers found during prep (fix BEFORE submitting the campaign)
+
+- ☐ **[HIGH — issue #19] `LUMINOSITY_DISTANCE_PRESCREEN_GPC = 2.0` is stale.**
+  Calibrated on retired pre-dt² injection data ("no detectable EMRI beyond 1.66 Gpc");
+  at physical SNR the horizon is z ≲ 1.5 (d_L ~ 11 Gpc). Running the campaign with it
+  silently truncates the detectable population (DEBUG-level log only).
+  Fix via `/physics-change`: derive from the M1 rate model's z_max at the smallest
+  grid h (× margin), or minimally bump to ≳ 16 Gpc and re-measure from the first
+  post-fix injection pool. **Do not submit the campaign before this lands.**
+- ☐ **`PRE_SCREEN_SNR_FACTOR = 0.3` empirical re-check** (sign-off campaign-time action).
+  Ratio-based, survives the dt² rescaling in principle, but the false-negative rate must
+  be re-measured at the new depth (longer, more-redshifted waveforms): in the smoke run,
+  disable the quick-SNR gate for N≈100 events, record (quick_snr, full_snr) pairs, verify
+  no full-SNR ≥ 20 event has quick < 6. Same `/physics-change` run as issue #19 if the
+  factor moves.
+
+## 2. Blocked on seed600 jobs finishing (do NOT touch the cluster repo before)
+
+The queued eval must run against the cluster state it was configured for
+(branch @ `6d4c4e1`, z_helio catalogue) to stay apples-to-apples with the archived
+railed baseline. After combine `5698618` completes and results are retrieved+verified:
+
+- ☐ `git fetch && git checkout main && git pull` on `~/MasterThesisCode` (cluster).
+- ☐ Stage the **rebuilt z_cmb catalogue** (local rebuild 2026-07-02; 99.9 % rows shifted,
+  median |Δz| 6e-4):
+  `rsync -avz --partial master_thesis_code/galaxy_catalogue/reduced_galaxy_catalogue.csv bwunicluster:MasterThesisCode/master_thesis_code/galaxy_catalogue/`
+  then re-run preflight → require `VERDICT: READY ✓` **and 8-col schema confirmation**.
+- ☐ Note: committed de-rail/ablation baselines refer to the z_helio catalogue (sign-off
+  "Open, non-blocking"); the campaign runs z_cmb — never mix in one comparison.
+
+## 3. Campaign design (per roadmap Phase 2)
+
+- Injections: regenerate at **single h_ref = 0.73** with the M_z convention
+  (p_det h-invariance established 2026-06-21; simplifies `submit_injection.sh` — see
+  memory `project_injection_todo`). Post-fix SNR scale ⇒ deeper pool: budget for more
+  events per task and re-tuned `--time` (see §4 timeouts).
+- Simulations: **4 seeds @ h_true = 0.73** + closure truths **0.67 / 0.77** (1 seed each).
+- Inference: `--normalization_mode volume_deconv` (default), seeded (`--seed` reaches
+  inference, G4); 38-value h-grid first pass.
+- Budget ~1800 cpu-h + GPU sim time. Queue strategy: `cpu` + `cpu_il` multi-partition
+  (this prep's escalation shows `cpu_il` drains overnight); submit before 20:00 only to
+  `cpu`; **never cancel to chase slots** (W-LOOP-04).
+- Workspace: `ws_find emri` → extended to 2026-08-31 (Phase 0). `ws_extend emri 60` again
+  if the campaign slips past mid-August. Immediate rsync-back after every stage.
+- Provenance: `run_metadata_<task>.json` carries git_commit+seed+args; tag the campaign
+  base commit (`campaign-phase2-base`) before first submit; DATA_INVENTORY tier update
+  with the new datasets; retire/label pre-dt² datasets explicitly.
+
+## 4. Campaign-time actions (from the sign-off — wire these into the runs)
+
+- ☐ **Timeout histograms by (M, e₀, p₀)**: G9 landed per-parameter logging; harvest the
+  logs of the smoke run + first seed into histograms (0.6–1.25 %/stage at the old scale;
+  expect drift at longer waveforms). If loss concentrates in a corner, quote it in the
+  Paper-B systematics rather than raising timeouts blindly.
+- ☐ **κ-gate exclusion count**: G10 gate (κ > 1e14 skips event) — count skips per seed
+  from logs; report alongside the timeout budget.
+- ☐ **Per-seed `pp_coverage` runs**: `master_thesis_code.validation.pp_coverage` (G4b)
+  once per seed; collect into one P–P figure across seeds.
+- ☐ **Finer-grid pass** on the final combined posterior (superdense grid around the MAP;
+  posterior filenames support 4-decimal h since b1933d8).
+- ☐ **Smoke test first**: `--tasks 2 --steps 10` (cluster skill golden rule) + the §1
+  pre-screen measurements, THEN full submission.
+
+## 5. Paper hooks
+
+- Paper A (`paper_a/`, drafting in flight): consumes the seed600 confirmation (§0) into
+  its RESULT PENDING slot; campaign P–P-across-seeds figure is an optional strengthener.
+- Paper B: campaign is its data source; wire the one-command `paper/figures` regeneration
+  script during harvest, not after.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   library/test callers of `main.main()` are unaffected (`os._exit` would
   otherwise terminate a hosting pytest process).
 
+### Fixed (campaign prep)
+- **[PHYSICS] population-derived d_L pre-screen replaces the stale 2.0 Gpc cutoff (issue #19):**
+  `LUMINOSITY_DISTANCE_PRESCREEN_GPC = 2.0` was calibrated on retired pre-dt² (SNR/10-scale)
+  injection data ("no detectable EMRI beyond 1.66 Gpc") and lay *inside* the z ≤ 0.5 host-draw
+  volume — d_L(0.5; h=0.73) = 2.74 Gpc — silently cutting in-population events at DEBUG level.
+  The simulation loop now computes `physical_relations.luminosity_distance_prescreen_gpc(z_max, h)`
+  = `PRESCREEN_DL_MARGIN (1.05) × d_L(rate-model z_max; runtime h)` once per run (11.22 Gpc at the
+  fiducial cosmology): inert for in-population events by construction, so a hit now logs at
+  WARNING (pathological draw). Margin is a placeholder until re-measured on post-dt² injection
+  data (`.planning/CAMPAIGN-PREP-PHASE2.md` §1). Refs: Babak et al. (2017) arXiv:1703.09722;
+  Hogg (1999) arXiv:astro-ph/9905116 Eq. (16).
+
 ### Added
 - **`master_thesis_code.validation` subpackage (G4b):** the 2026-07-01 commission's
   independent P–P/coverage calibration harness (investigator d2) promoted from

--- a/master_thesis_code/constants.py
+++ b/master_thesis_code/constants.py
@@ -73,7 +73,12 @@ GALAXY_CATALOG_REDSHIFT_UPPER_LIMIT: float = 0.55  # maximum redshift for galaxy
 # (p_det = 0 beyond) and only removes never-detectable host candidates.
 HOST_DRAW_Z_MAX: float = 0.5
 LUMINOSITY_DISTANCE_THRESHOLD_GPC: float = 1.55  # Gpc, LISA detection horizon for EMRIs
-LUMINOSITY_DISTANCE_PRESCREEN_GPC: float = 2.0  # Gpc, generous pre-screen cutoff (see main.py)
+# Multiplicative safety margin on the population-derived d_L pre-screen bound
+# (physical_relations.luminosity_distance_prescreen_gpc). Placeholder pending
+# re-measurement on post-dt^2 injection data — issue #19. Replaces the retired
+# LUMINOSITY_DISTANCE_PRESCREEN_GPC = 2.0, which was calibrated on pre-dt^2
+# (SNR/10-scale) injections and lay inside the z <= 0.5 host-draw volume.
+PRESCREEN_DL_MARGIN: float = 1.05
 
 # saving Cramer-Rao bounds for marginalization.
 CRAMER_RAO_BOUNDS_PATH: str = "simulations/cramer_rao_bounds_simulation_$index.csv"

--- a/master_thesis_code/main.py
+++ b/master_thesis_code/main.py
@@ -380,14 +380,15 @@ def data_simulation(
 
     from master_thesis_code.constants import (
         HOST_DRAW_Z_MAX,
-        LUMINOSITY_DISTANCE_PRESCREEN_GPC,
         PRE_SCREEN_SNR_FACTOR,
+        PRESCREEN_DL_MARGIN,
     )
     from master_thesis_code.dark_siren_injection import (
         compute_global_catalog_fraction,
         draw_mixture_hosts,
     )
     from master_thesis_code.galaxy_catalogue.pixel_completeness import from_cache_or_build
+    from master_thesis_code.physical_relations import luminosity_distance_prescreen_gpc
 
     # CHANGE 4b/5: split injected hosts into an in-catalog fraction F and an
     # out-of-catalog (dark) fraction 1-F so the injected population matches the
@@ -408,6 +409,23 @@ def data_simulation(
         h_value,
         HOST_DRAW_Z_MAX,
         1.0 - global_catalog_fraction,
+    )
+
+    # Population-derived d_L pre-screen (issue #19): the M1 rate model samples
+    # z <= max_redshift, so no valid event lies beyond d_L(max_redshift; h_value).
+    # At physical SNR semantics (G8 dt² fix) the EMRI detection horizon exceeds
+    # this reach — the pre-screen is inert for in-population events and only
+    # guards pathological draws. Margin pending post-dt² injection re-measurement.
+    # Babak et al. (2017), arXiv:1703.09722; Hogg (1999), arXiv:astro-ph/9905116 Eq. (16).
+    d_L_prescreen_gpc = luminosity_distance_prescreen_gpc(
+        cosmological_model.max_redshift, h=h_value
+    )
+    _ROOT_LOGGER.info(
+        "d_L pre-screen bound: %.3f Gpc (z_max=%.2f, h=%.4f, margin=%.2f).",
+        d_L_prescreen_gpc,
+        cosmological_model.max_redshift,
+        h_value,
+        PRESCREEN_DL_MARGIN,
     )
 
     counter = 0
@@ -457,18 +475,18 @@ def data_simulation(
 
         parameter_estimation.parameter_space.set_host_galaxy_parameters(host_galaxy, h=h_value)
 
-        # Distance pre-screen: skip events far beyond LISA's EMRI detection horizon
-        # (~1.55 Gpc) before generating any waveform.  The 2.0 Gpc cutoff includes
-        # generous margin for orientation-dependent SNR boosts.  No detectable EMRI
-        # (SNR >= 20) has ever been observed beyond d_L ~ 1.66 Gpc in injection data
-        # (165 000 events).  P_det is already 0 at these distances, so this cut
-        # does not affect the Bayesian inference.
+        # Distance pre-screen: skip pathological events beyond the population's
+        # maximum reach (d_L_prescreen_gpc, derived above from the rate model's
+        # z_max at the runtime h) before generating any waveform. Inert for
+        # in-population events by construction — a hit here indicates a bad
+        # draw, hence WARNING, not DEBUG (issue #19).
         d_L = parameter_estimation.parameter_space.luminosity_distance.value
-        if d_L > LUMINOSITY_DISTANCE_PRESCREEN_GPC:
-            _ROOT_LOGGER.debug(
-                "Skipping event: d_L = %.2f Gpc > %.1f Gpc pre-screen cutoff.",
+        if d_L > d_L_prescreen_gpc:
+            _ROOT_LOGGER.warning(
+                "Skipping event: d_L = %.2f Gpc > %.3f Gpc population-derived "
+                "pre-screen bound (pathological draw?).",
                 d_L,
-                LUMINOSITY_DISTANCE_PRESCREEN_GPC,
+                d_L_prescreen_gpc,
             )
             continue
 

--- a/master_thesis_code/physical_relations.py
+++ b/master_thesis_code/physical_relations.py
@@ -17,6 +17,7 @@ from master_thesis_code.constants import (
     KM_TO_M,
     OMEGA_DE,
     OMEGA_M,
+    PRESCREEN_DL_MARGIN,
     SPEED_OF_LIGHT_KM_S,
     W_0,
     W_A,
@@ -152,6 +153,46 @@ def dist_vectorized(
     result = C / H_0 * (1 + redshift) * integral - offset_for_root_finding
 
     return result
+
+
+def luminosity_distance_prescreen_gpc(
+    z_max: float,
+    h: float,
+    Omega_m: float = OMEGA_M,
+    Omega_de: float = OMEGA_DE,
+    margin: float = PRESCREEN_DL_MARGIN,
+) -> float:
+    """Population-derived luminosity-distance pre-screen bound in Gpc.
+
+    The simulation loop skips events with :math:`d_L` above this bound before
+    generating any waveform. The bound is the luminosity distance of the rate
+    model's maximum sampled redshift, inflated by a small safety margin, so no
+    in-population event can be cut — at physical SNR semantics (G8 dt² fix) the
+    EMRI detection horizon (z ≈ 1.5–3.8) exceeds the population reach, making
+    the pre-screen inert for valid events; it only guards pathological draws.
+
+    Supersedes the retired ``LUMINOSITY_DISTANCE_PRESCREEN_GPC = 2.0``, which
+    was calibrated on pre-dt² (SNR/10-scale) injection data and lay inside the
+    z ≤ 0.5 host-draw volume (issue #19). The margin is a placeholder until
+    re-measured on post-dt² injection data.
+
+    Args:
+        z_max: Maximum redshift sampled by the population model
+            (``Model1CrossCheck.max_redshift``).
+        h: Dimensionless Hubble parameter of the current run.
+        Omega_m: Matter density parameter.
+        Omega_de: Dark energy density parameter.
+        margin: Multiplicative safety margin (≥ 1).
+
+    Returns:
+        Pre-screen bound in Gpc; 0.0 exactly at ``z_max = 0``.
+
+    References:
+        Babak et al. (2017), arXiv:1703.09722 (M1 population; EMRI horizon);
+        Hogg (1999), arXiv:astro-ph/9905116 Eq. (16) via :func:`dist`.
+    """
+    # d_L(z_max; h) × margin — Hogg (1999), arXiv:astro-ph/9905116 Eq. (16)
+    return margin * dist(z_max, h=h, Omega_m=Omega_m, Omega_de=Omega_de)
 
 
 def dist_derivative(

--- a/master_thesis_code_test/physical_relations_test.py
+++ b/master_thesis_code_test/physical_relations_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from master_thesis_code.constants import OMEGA_DE, OMEGA_M, W_0, W_A, H
+from master_thesis_code.constants import HOST_DRAW_Z_MAX, OMEGA_DE, OMEGA_M, W_0, W_A, H
 from master_thesis_code.physical_relations import (
     convert_redshifted_mass_to_true_mass,
     convert_true_mass_to_redshifted_mass,
@@ -12,6 +12,7 @@ from master_thesis_code.physical_relations import (
     dist_vectorized,
     get_redshift_outer_bounds,
     hubble_function,
+    luminosity_distance_prescreen_gpc,
 )
 
 
@@ -172,3 +173,43 @@ def test_dist_hubble_scaling_approximate() -> None:
     actual_ratio = d1 / d2
     # Tolerance of 2% to account for non-linear corrections at z=0.1
     assert abs(actual_ratio - expected_ratio) < 0.02
+
+
+# --- luminosity_distance_prescreen_gpc (issue #19) ---------------------------------
+# Regression context: the retired constant LUMINOSITY_DISTANCE_PRESCREEN_GPC = 2.0
+# was calibrated on pre-dt^2 (SNR/10-scale) injection data ("no detectable EMRI
+# beyond 1.66 Gpc") and lay INSIDE the z <= HOST_DRAW_Z_MAX = 0.5 host-draw volume,
+# silently cutting in-population events. The bound is now derived from the
+# population reach at the runtime h.
+
+
+def test_retired_2gpc_prescreen_truncated_host_population() -> None:
+    """The old fixed 2.0 Gpc cutoff lay inside the z <= 0.5 host-draw volume."""
+    assert dist(HOST_DRAW_Z_MAX, h=H) > 2.0
+
+
+def test_prescreen_bound_contains_population_reach() -> None:
+    """Limiting case: bound >= d_L(z_max, h) for all grid h values, so the
+    pre-screen is inert for in-population events (no valid event can be cut)."""
+    z_max = 1.5
+    for h in (0.60, 0.73, 0.86):
+        assert luminosity_distance_prescreen_gpc(z_max, h=h) >= dist(z_max, h=h)
+
+
+def test_prescreen_bound_value_at_fiducial() -> None:
+    """Pin the derived bound at the fiducial cosmology:
+    1.05 * d_L(1.5, h=0.73, Omega_m=0.2726) = 1.05 * 10.6862 Gpc."""
+    assert luminosity_distance_prescreen_gpc(1.5, h=0.73) == pytest.approx(11.2205, abs=0.001)
+
+
+def test_prescreen_bound_increases_when_h_decreases() -> None:
+    """d_L ~ 1/h at fixed z, so the bound must widen for smaller h."""
+    assert luminosity_distance_prescreen_gpc(1.5, h=0.60) > luminosity_distance_prescreen_gpc(
+        1.5, h=0.86
+    )
+
+
+def test_prescreen_bound_zero_redshift_limit() -> None:
+    """Analytic limit: dist(0) = 0, so the bound vanishes at z_max = 0
+    (up to float residue of the hypergeometric evaluation, ~1e-15 Gpc)."""
+    assert luminosity_distance_prescreen_gpc(0.0, h=0.73) == pytest.approx(0.0, abs=1e-12)


### PR DESCRIPTION
## What

Two commits preparing the Phase-2 multi-seed campaign (gate is PASSED, sign-off in `.planning/gate/GATE_SIGNOFF.md`):

1. **`180c7c3` docs(campaign):** `.planning/CAMPAIGN-PREP-PHASE2.md` — ordered runbook for the sign-off's campaign-time actions: pre-submit blockers, items blocked on the seed600 confirmation jobs, campaign design (single h_ref injections, 4+2 seeds, volume_deconv, provenance tagging), in-campaign instrumentation (timeout histograms by (M,e₀,p₀), κ-gate counts, per-seed pp_coverage, finer-grid pass).

2. **`b7e3edd` [PHYSICS]:** fixes #19 — `LUMINOSITY_DISTANCE_PRESCREEN_GPC = 2.0` was calibrated on retired pre-dt² injection data and lay **inside** the current z ≤ 0.5 host-draw volume (d_L(0.5; h=0.73) = 2.74 Gpc), silently cutting in-population events at DEBUG level. Replaced by `physical_relations.luminosity_distance_prescreen_gpc(z_max, h)` = `PRESCREEN_DL_MARGIN (1.05) × d_L(rate-model z_max; runtime h)`, computed once per run (11.22 Gpc at fiducial cosmology) — inert for in-population events by construction; a hit now logs at WARNING. Margin re-measurement on post-dt² injection data stays tracked in #19 (user decision).

## Physics-change protocol

Presented and user-approved 2026-07-02. Limiting cases in tests: bound ≥ d_L(z_max,h) ∀ grid h (inertness), bound → 0 at z_max → 0, bound ∝ 1/h monotonicity; value pinned 11.2205 Gpc. 5 regression tests incl. documentation of the old constant's failure. Suite 723 passed / mypy / ruff clean.

## Related

- #19 (stays open for margin re-measurement)
- #20 (NEW, found during this work): `HOST_DRAW_Z_MAX = 0.5` population-depth design decision — **blocks campaign submission**, needs user decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)