### PR TITLE
fix: dedup out-of-grid quadrature warning to once per event

### DIFF
--- a/master_thesis_code/bayesian_inference/bayesian_statistics.py
+++ b/master_thesis_code/bayesian_inference/bayesian_statistics.py
@@ -65,6 +65,38 @@ from master_thesis_code.physical_relations import (
 
 _LOGGER = logging.getLogger()
 
+# Per-process dedup state for the out-of-grid quadrature warning: the check runs
+# per (event, host) and produced O(10^5) identical lines per task on large
+# campaigns, so we warn once per event and count suppressed repeats instead.
+_quadrature_outside_grid_warned_events: set[int] = set()
+_quadrature_outside_grid_suppressed_repeats: int = 0
+
+
+def _warn_quadrature_weight_outside_grid(
+    detection_index: int,
+    weight_outside_numerator: float,
+    weight_outside_denominator: float,
+) -> None:
+    """Emit the >5% out-of-grid quadrature warning at most once per event.
+
+    Subsequent occurrences for the same event (per worker process) only
+    increment ``_quadrature_outside_grid_suppressed_repeats``. Logging-only:
+    the returned diagnostic weights are unaffected.
+    """
+    global _quadrature_outside_grid_suppressed_repeats
+    if detection_index in _quadrature_outside_grid_warned_events:
+        _quadrature_outside_grid_suppressed_repeats += 1
+        return
+    _quadrature_outside_grid_warned_events.add(detection_index)
+    _LOGGER.warning(
+        "Event %d: >5%% quadrature weight outside P_det grid — "
+        "numerator=%.3f, denominator=%.3f (repeats for this event suppressed)",
+        detection_index,
+        weight_outside_numerator,
+        weight_outside_denominator,
+    )
+
+
 DEFAULT_GALAXY_Z_ERROR = 0.0015
 GALAXY_LIKELIHOODS = "galaxy_likelihoods"
 ADDITIONAL_GALAXIES_WITHOUT_BH_MASS = "additional_galaxies_without_bh_mass"
@@ -3303,9 +3335,7 @@ def single_host_likelihood(
         quadrature_weight_outside_grid_numerator > 0.05
         or quadrature_weight_outside_grid_denominator > 0.05
     ):
-        _LOGGER.warning(
-            "Event %d: >5%% quadrature weight outside P_det grid — "
-            "numerator=%.3f, denominator=%.3f",
+        _warn_quadrature_weight_outside_grid(
             detection_index,
             quadrature_weight_outside_grid_numerator,
             quadrature_weight_outside_grid_denominator,
@@ -3750,12 +3780,10 @@ def single_host_likelihood_batch(
         (quadrature_weight_outside_grid_numerator > 0.05)
         | (quadrature_weight_outside_grid_denominator > 0.05)
     ):
-        _LOGGER.warning(
-            "Event %d: >5%% quadrature weight outside P_det grid — "
-            "numerator=%.3f, denominator=%.3f",
+        _warn_quadrature_weight_outside_grid(
             detection_index,
-            quadrature_weight_outside_grid_numerator[_flagged],
-            quadrature_weight_outside_grid_denominator[_flagged],
+            float(quadrature_weight_outside_grid_numerator[_flagged]),
+            float(quadrature_weight_outside_grid_denominator[_flagged]),
         )
 
     if not evaluate_with_bh_mass:

--- a/master_thesis_code_test/bayesian_inference/test_quadrature_warning_dedup.py
+++ b/master_thesis_code_test/bayesian_inference/test_quadrature_warning_dedup.py
@@ -1,0 +1,32 @@
+"""Once-per-event dedup of the out-of-grid quadrature warning (log hygiene)."""
+
+import logging
+
+import pytest
+
+from master_thesis_code.bayesian_inference import bayesian_statistics as bs
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup_state() -> None:
+    bs._quadrature_outside_grid_warned_events.clear()
+    bs._quadrature_outside_grid_suppressed_repeats = 0
+
+
+def test_warns_once_per_event_and_counts_repeats(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        bs._warn_quadrature_weight_outside_grid(7, 0.10, 0.02)
+        bs._warn_quadrature_weight_outside_grid(7, 0.11, 0.03)
+        bs._warn_quadrature_weight_outside_grid(7, 0.12, 0.04)
+    warnings = [r for r in caplog.records if "quadrature weight outside" in r.message]
+    assert len(warnings) == 1
+    assert bs._quadrature_outside_grid_suppressed_repeats == 2
+
+
+def test_distinct_events_each_warn(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        bs._warn_quadrature_weight_outside_grid(1, 0.10, 0.02)
+        bs._warn_quadrature_weight_outside_grid(2, 0.10, 0.02)
+    warnings = [r for r in caplog.records if "quadrature weight outside" in r.message]
+    assert len(warnings) == 2
+    assert bs._quadrature_outside_grid_suppressed_repeats == 0


### PR DESCRIPTION
Runbook thread 7 (log hygiene, pre-requisite for the next large campaign): the `>5% quadrature weight outside P_det grid` warning fired per (event, host, h-node) — ~5×10⁵ lines/task, 0.8–1.3 GB logs per prodstack run.

- Warn once per event per worker process via a module-level dedup set; suppressed repeats counted in `_quadrature_outside_grid_suppressed_repeats`.
- Logging-only change: diagnostic weight columns and all computed values untouched.
- New unit test `test_quadrature_warning_dedup.py`; full `bayesian_inference` suite green (349 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG4aVbnNjRbWP3daBufoQX