### PR TITLE
paper: fill production-run numbers (22/24 pending markers)

### DIFF
--- a/paper/main.tex
+++ b/paper/main.tex
@@ -49,11 +49,20 @@ $\dL$--$z$ degeneracy inherent in the dark siren method.
 Using Fisher-matrix-based Cram\'er--Rao bounds for a population of
 detected EMRIs and the completeness-corrected galaxy catalog likelihood of
 Gray~\textit{et~al.}\ [Phys.\ Rev.\ D \textbf{101}, 122001 (2020)],
-we find that including~$\Mz$ tightens the $\HH$~constraint from
-\pending{$\sim\!4\%$} to \pending{$\sim\!1.8\%$} precision,
-a factor of~$\sim\!2$ improvement.  We discuss the impact of catalog
-incompleteness, detection probability estimation, and systematic
-effects on the posterior.
+we perform a multi-seed production mock campaign with a
+generator-marginal likelihood normalization and an injection-based,
+redshift-resolved survival estimate of the detection probability.
+Both channels recover the injected value ($h = 0.73$) to within
+$\sim\!1\sigma$, with a measured posterior width of
+$\sigma_h \approx 2\times10^{-4}$ ($\approx\!0.03\%$) in the deep
+production venues; this precision is mock-internal, as the exact
+source--host pairing of the simulation removes peculiar-velocity and
+redshift-measurement errors present in real data.  The two channels
+yield near-identical widths in this configuration; the benefit of the
+mass channel appears as a sharper, more robust host association
+carried by rare exact-host events rather than as a reduced posterior
+width.  We discuss the impact of catalog incompleteness, detection
+probability estimation, and systematic effects on the posterior.
 \end{abstract}
 
 \maketitle

--- a/paper/sections/conclusions.tex
+++ b/paper/sections/conclusions.tex
@@ -5,10 +5,23 @@
 We have investigated whether the redshifted massive black hole mass
 $\Mz$, precisely measured from the EMRI gravitational waveform, can
 improve dark siren constraints on the Hubble constant $\HH$ with LISA.
-The answer is affirmative.  Including $\Mz$ in the Bayesian inference
-tightens the $\HH$ posterior by a factor of $\sim 2$, from
-$\sim 4\%$ to $\sim 1.8\%$ precision in the $\pdet = 1$ baseline
-(\pending{update with production run precision}).  The mechanism is
+In the $\pdet = 1$ thesis baseline, including $\Mz$ in the Bayesian
+inference tightened the $\HH$ posterior by a factor of $\sim 2$, from
+$\sim 4\%$ to $\sim 1.8\%$ precision.  In the production configuration
+(generator-marginal likelihood normalization with a redshift-resolved
+survival estimate of $\pdet$), both channels reach a measured posterior
+width of $\sigma_h \approx 2\times10^{-4}$ ($\approx 0.03\%$) in the
+deep venues, with the maximum a posteriori value within $\sim 1\sigma$
+of the injected $h = 0.73$; the two channels' widths are
+near-identical, and the value of the mass channel manifests as a more
+robust host association carried by rare exact-host events rather than
+as a width improvement.  These precision figures are mock-internal:
+the exact point-to-point pairing of GW sources with catalog hosts in
+the simulation removes peculiar-velocity and redshift-measurement
+errors present in real data.
+\todo{author: reconcile factor-$\sim2$ narrative with production
+result --- measured widths are near-identical across channels}
+The mechanism is
 straightforward: the GW measurement determines $\Mz$ to fractional
 precision $\lesssim 10^{-6}$, while the galaxy-side BH mass estimate
 from the $\Mbh$--$\Mstellar$ scaling relation carries $\sim 20\%$

--- a/paper/sections/results.tex
+++ b/paper/sections/results.tex
@@ -44,10 +44,17 @@ with the minimum ratio of $124$ occurring at $h = 0.90$.
 For the posterior evaluation, we further require that each detection has a
 relative luminosity distance uncertainty
 $\sigma_{\dL}/\dL < 0.10$, as estimated from the Cram\'{e}r--Rao
-bound. This cut reduces the sample to
-\pending{N\_det posterior after $\sigma_{d_L}/d_L < 0.10$ cut from
-production run} detections
-(thesis baseline: $N_\mathrm{det}^\mathrm{post} = 223$).
+bound. In the production campaign the posterior evaluation uses
+$N_\mathrm{det} = 3314$ events in the headline venue (seed 3000); the
+three deep production venues (seeds 1000, 2000, 3000) contain
+3454, 3254, and 3314 events, respectively
+(thesis baseline: $N_\mathrm{det}^\mathrm{post} = 223$). The cut is
+applied unconditionally in the production evaluation; e.g.\ in the
+seed-1000 venue it reduces the sample from 3470 to 3454 detections.
+\todo{author: legacy thesis-campaign numbers above (165{,}000
+injections, 663 detections, 7 $h$-values) predate the production
+campaign (canonical 50k injection pool, 41-point $h$ grid) ---
+reconcile with production injection pool}
 
 \begin{figure}[t]
   \centering
@@ -129,30 +136,47 @@ using $\Mz$).
 
 \paragraph{Without MBH mass.}
 The posterior using only distance and sky localization yields
-\pending{production run value for $h^\mathrm{(no\,mass)}$}
 \begin{equation}
-  h^\mathrm{(no\,mass)} = 0.712 \pm 0.028 \,,
+  h^\mathrm{(no\,mass)} = 0.72979 \pm 0.00022 \,,
   \label{eq:h0_no_mass}
 \end{equation}
-at $1\sigma$, corresponding to $\sim 4\%$ measurement precision
-(\pending{update with production run precision}).
-The value quoted above is the thesis baseline with $\pdet = 1$.
+at $1\sigma$, measured on a dense $h$ grid ($10^{-4}$ spacing) in the
+headline production venue (seed 3000, 3314 events), corresponding to
+$\approx 0.03\%$ statistical precision
+(thesis baseline with $\pdet = 1$: $0.712 \pm 0.028$, i.e.\
+$\sim 4\%$).
+These precision figures are mock-internal: the exact point-to-point
+pairing of GW sources with catalog hosts in the simulation removes
+peculiar-velocity and redshift-measurement errors present in real
+data, so they characterize the statistical width of the estimator on
+this mock rather than a forecast for LISA.
 
 \paragraph{With MBH mass.}
-Including the redshifted MBH mass tightens the posterior to
-\pending{production run value for $h^\mathrm{(mass)}$}
+Including the redshifted MBH mass yields
 \begin{equation}
-  h^\mathrm{(mass)} = 0.742 \pm 0.013 \,,
+  h^\mathrm{(mass)} = 0.72988 \pm 0.00021 \,,
   \label{eq:h0_with_mass}
 \end{equation}
-at $1\sigma$, corresponding to $\sim 1.8\%$ measurement precision
-(\pending{update with production run precision}).
-The value quoted above is the thesis baseline with $\pdet = 1$.
+at $1\sigma$ in the same venue and on the same dense grid, i.e.\ also
+$\approx 0.03\%$ --- statistically indistinguishable from the
+distance-only channel in the production configuration
+(thesis baseline with $\pdet = 1$: $0.742 \pm 0.013$, i.e.\
+$\sim 1.8\%$).
 
 \paragraph{Improvement factor.}
-Including $\Mz$ in the inference tightens the $\HH$ constraint by a
-factor of $\sim 2$ in precision (from $\sim 4\%$ to $\sim 1.8\%$ in the
-$\pdet = 1$ baseline). The physical mechanism is as follows. Without the
+In the $\pdet = 1$ thesis baseline, including $\Mz$ tightened the
+$\HH$ constraint by a factor of $\sim 2$ in precision (from
+$\sim 4\%$ to $\sim 1.8\%$). In the production configuration the
+measured widths of the two channels are near-identical
+($\sigma_h \approx 2.1$--$2.5\times10^{-4}$ in both), and the value of
+the mass channel appears instead as robustness of the host
+association: the statistical information is concentrated in a small
+population of exact-host (``golden'') events, whose calibrated pulls
+(mean $+0.06$, standard deviation $0.94$ over $\sim 133$ events)
+validate the host association and generator consistency.
+\todo{author: reconcile with production result --- measured widths are
+near-identical across channels}
+The physical mechanism is as follows. Without the
 mass channel, each GW detection constrains a degenerate combination of
 $\dL$ and $z$: for a given measured $\dL$ at trial $\HH$, many candidate
 host galaxies at different redshifts can reproduce the observed distance.
@@ -174,12 +198,13 @@ correct redshift and hence the correct $\HH$.
   mass. Red dashed --- with MBH mass. Vertical gray line at $h = 0.73$
   (injected value). Shaded $1\sigma$ bands.}
   \caption{Posterior on the Hubble constant $\HH$ from
-  \pending{N\_det} EMRI dark siren events. The blue curve uses only
-  the luminosity distance and sky position
+  $3314$ EMRI dark siren events (production venue, seed 3000). The
+  blue curve uses only the luminosity distance and sky position
   (Eq.~\ref{eq:h0_no_mass}); the red curve additionally incorporates
   the redshifted MBH mass (Eq.~\ref{eq:h0_with_mass}). The vertical
-  dashed line marks the injected value $h = 0.73$. Including the mass
-  information tightens the constraint by a factor of $\sim 2$.}
+  dashed line marks the injected value $h = 0.73$. In the production
+  configuration the two channels yield near-identical posterior widths
+  (see text).}
   \label{fig:posterior_comparison}
 \end{figure}
 
@@ -210,7 +235,10 @@ redshift.
 \paragraph{Convergence with event number.}
 To assess the scaling of the $\HH$ constraint with the number of
 detections, we evaluate the posterior on random subsets of
-\pending{subset size} events drawn from the full catalog. The
+\pending{subset size} events drawn from the full catalog.
+\todo{bootstrap analysis job pending --- needs event\_likelihoods.csv
+retrieval from cluster}
+The
 posterior width narrows approximately as $N_\mathrm{det}^{-1/2}$
 for both channels, as expected for independent measurements. With $\Mz$
 information, a precision of $\sim 2\%$ is reached with
@@ -224,7 +252,9 @@ catalog for a comparable constraint.
   for both channels. Dashed line: $N^{-1/2}$ scaling.}
   \caption{Convergence of the $\HH$ posterior width with the number of
   EMRI detections. Points show the median $1\sigma$ width from
-  \pending{N\_subsets} random subsets; error bars indicate the
+  \pending{N\_subsets} random subsets
+  \todo{bootstrap analysis job pending --- needs
+  event\_likelihoods.csv retrieval from cluster}; error bars indicate the
   16th--84th percentile range. The dashed line shows the expected
   $N^{-1/2}$ scaling. The ``with mass'' channel (red) reaches $2\%$
   precision with $\sim 200$ events.}
@@ -236,9 +266,12 @@ catalog for a comparable constraint.
 \label{sec:pdet_completeness}
 %% ============================================================
 
-The results in Sec.~\ref{sec:h0_posterior} were obtained with the
-detection probability $\pdet$ set to unity. We now assess the impact of a
-realistic $\pdet$ and catalog completeness correction.
+The production results in Sec.~\ref{sec:h0_posterior} are obtained
+with a realistic detection probability and the completeness-corrected
+likelihood; the thesis-baseline values quoted alongside them were
+obtained with $\pdet$ set to unity. We now describe the realistic
+$\pdet$ and the catalog completeness correction, and quantify their
+impact.
 
 \paragraph{Detection probability.}
 The detection probability $\pdet(\dL, \Mbh, h)$ is estimated via
@@ -247,7 +280,20 @@ campaign (Sec.~\ref{sec:method}), validated with Wilson confidence
 interval overlap across $916$ grid bins with zero
 Benjamini--Hochberg--adjusted false
 discoveries~\cite{Farr:2019rap,Tiwari:2017ndi}.
-\pending{Present results with realistic $\pdet$ from production run.}
+\todo{author: $\pdet$ description above predates the
+redshift-resolved survival estimator used in the production stack}
+The production analysis uses a redshift-resolved survival estimator
+for $\pdet$, built from the canonical 50k injection pool, combined
+with a generator-marginal normalization of the single-event
+likelihood. With this stack, the four provenance-valid production
+venues show no detectable bias: the posterior peaks at the grid node
+$h = 0.730$ in all four venues and both channels, bounding
+$|\Delta h| \lesssim 0.0025$ at grid resolution, and the dense-core
+measurement on the out-of-sample venues (seeds 2000 and 3000) gives a
+combined offset from truth of $-0.0002 \pm 0.0002$. As throughout,
+these precision statements are mock-internal: the point/point pairing
+of injected and cataloged positions deletes peculiar-velocity and
+redshift-floor errors present in real data.
 
 \paragraph{Catalog completeness.}
 The GLADE+ galaxy catalog~\cite{Dalya:2021ewn} is incomplete at redshifts
@@ -292,10 +338,17 @@ with the requirement that the combined likelihood interpolates
 monotonically between the two terms, have been verified analytically and
 numerically.
 
-\pending{Show the effect of completeness correction on the $\HH$
-posterior bias. Thesis baseline without correction: $h = 0.712$ (without
-mass) and $h = 0.742$ (with mass). Production run with correction
-expected to reduce bias toward $h_\mathrm{true} = 0.73$.}
+With the full production stack (generator-marginal normalization and
+redshift-resolved survival $\pdet$), the measured posteriors are
+centered on the injected value: the maximum a posteriori node is
+$h = 0.730$ in all four provenance-valid venues and both channels
+($|\Delta h| \lesssim 0.0025$, grid-supported), and the dense-core
+measurement on seeds 2000 and 3000 yields a combined offset of
+$-0.0002 \pm 0.0002$ --- no detectable bias at the
+few~$\times 10^{-4}$ level. This removes the systematic offsets of
+the uncorrected thesis baseline, whose maximum a posteriori values
+were $h = 0.712$ (without mass) and $h = 0.742$ (with mass) against
+$h_\mathrm{true} = 0.73$.
 
 %% ============================================================
 \subsection{Systematic effects}
@@ -336,47 +389,63 @@ In the $\pdet = 1$ baseline, this effect is absent by construction, but
 with a realistic $\pdet$ estimated from an injection campaign of
 finite size, the normalization carries a statistical uncertainty of
 $\sim 1/\sqrt{N_\mathrm{inj}}$ per grid bin.
-\pending{Quantify residual $\pdet$ normalization effect from production
-run.}
+In the production campaign the residual effect is bounded by the
+multi-seed readout: across the four provenance-valid venues the
+ensemble bias is $-0.00030 \pm 0.00035$ (distance-only channel,
+parabolic sub-grid estimate) and $-0.00003 \pm 0.00018$ (mass
+channel), with the dense-core measured offset $-0.0002 \pm 0.0002$
+and the grid-supported bound $|\Delta h| \lesssim 0.0025$. One venue
+(seed 900) was excluded from these statistics for a diagnosed
+injection-pool provenance defect that undersampled the survival
+estimator (effective-sample-size floor violated in $58\%$ of sky-band
+cells); its re-run with the canonical pool produced an uninformative,
+zero-golden-event posterior and remains excluded on measured
+information content.
 
 Table~\ref{tab:results_summary} summarizes the key results for both
 inference channels.
 
 \begin{table}[t]
-  \caption{Summary of $\HH$ constraints from EMRI dark siren inference.
-  The injected value is $h_\mathrm{true} = 0.73$.
-  \pending{Update with production run values.}}
+  \caption{Per-venue summary of $\HH$ constraints from the production
+  EMRI dark siren campaign (generator-marginal normalization,
+  redshift-resolved survival $\pdet$). The injected value is
+  $h_\mathrm{true} = 0.73$. Seeds 2000 and 3000 are measured on a
+  dense $h$ grid ($10^{-4}$ spacing); seed 1000 values are parabolic
+  sub-grid estimates from the coarse 41-point grid, on which the peak
+  is not resolved. The mass channel excludes a constant 2 events per
+  venue. All precision figures are mock-internal: the exact
+  source--host pairing of the simulation removes peculiar-velocity
+  and redshift-measurement errors present in real data.}
   \label{tab:results_summary}
   \centering
-  \begin{tabular}{l c c}
+  \setlength{\tabcolsep}{2.5pt}
+  \begin{tabular}{l c c c c c}
     \hline\hline
-    & Without $\Mz$ & With $\Mz$ \\
+    & & \multicolumn{2}{c}{Without $\Mz$}
+      & \multicolumn{2}{c}{With $\Mz$} \\
+    Venue (seed) & $N_\mathrm{det}$ & MAP & $1\sigma$ & MAP & $1\sigma$ \\
     \hline
-    MAP estimate &
-      \pending{X.XXX} &
-      \pending{X.XXX} \\
-    $1\sigma$ width &
-      \pending{0.0XX} &
-      \pending{0.0XX} \\
-    Precision (\%) &
-      \pending{X.X} &
-      \pending{X.X} \\
-    Bias $\Delta h / h_\mathrm{true}$ (\%) &
-      \pending{X.X} &
-      \pending{X.X} \\
-    $N_\mathrm{det}$ used &
-      \multicolumn{2}{c}{\pending{NNN}} \\
+    1000 (coarse grid) & $3454$ & $0.7304$ & $0.00026$
+      & $0.7304$ & $0.00027$ \\
+    2000 (dense core)  & $3254$ & $0.72976$ & $0.00025$
+      & $0.72990$ & $0.00024$ \\
+    3000 (dense core)  & $3314$ & $0.72979$ & $0.00022$
+      & $0.72988$ & $0.00021$ \\
     \hline
-    \multicolumn{3}{l}{\emph{Thesis baseline ($\pdet = 1$):}} \\
-    MAP estimate &
-      $0.712$ &
-      $0.742$ \\
-    $1\sigma$ width &
-      $0.028$ &
-      $0.013$ \\
-    Precision (\%) &
-      $\sim 4$ &
-      $\sim 1.8$ \\
+    \multicolumn{6}{l}{\emph{Bias:} dense-core offset
+      $-0.0002 \pm 0.0002$ (not detectable);} \\
+    \multicolumn{6}{l}{grid-supported: MAP node $= 0.730$ in $4/4$
+      valid} \\
+    \multicolumn{6}{l}{venues, both channels
+      $\Rightarrow |\Delta h| \lesssim 0.0025$.} \\
+    \hline
+    \multicolumn{6}{l}{\emph{Thesis baseline ($\pdet = 1$):}} \\
+    MAP estimate & & \multicolumn{2}{c}{$0.712$}
+      & \multicolumn{2}{c}{$0.742$} \\
+    $1\sigma$ width & & \multicolumn{2}{c}{$0.028$}
+      & \multicolumn{2}{c}{$0.013$} \\
+    Precision (\%) & & \multicolumn{2}{c}{$\sim 4$}
+      & \multicolumn{2}{c}{$\sim 1.8$} \\
     \hline\hline
   \end{tabular}
 \end{table}


### PR DESCRIPTION
Runbook thread 4 (paper fill). Fills the measurement-backed `\pending{}` markers in `main.tex`, `sections/results.tex`, `sections/conclusions.tex` from the ratified campaign ledger (`MULTISEED_READOUT_20260726.md`).

**Headline (seed 3000, dense-core measured):** $h^{(\mathrm{no\,mass})} = 0.72979 \pm 0.00022$, $h^{(\mathrm{mass})} = 0.72988 \pm 0.00021$ (~0.03% mock-internal precision); thesis baselines moved to prose.
**Table:** rebuilt per-venue (seeds 1000/2000/3000, both channels, N_det, bias rows: dense-core $-0.0002 \pm 0.0002$, $|\Delta h| \lesssim 0.0025$ grid-supported in 4/4 venues); thesis-baseline block retained.
**Caveat:** mock-internal (rescope R3) sentence added once per precision-quoting subsection (abstract, h0_posterior, pdet_completeness, table caption, conclusions).
**p_det markers:** filled with the generator_marginal + z-resolved survival stack statements, incl. seed900 exclusion.

**Left for the author** (as `\todo` flags in-text):
- 2 remaining `\pending{}` (subset-convergence figure) — bootstrap-gated on `event_likelihoods.csv` retrieval from the cluster
- reconcile legacy thesis-campaign detection numbers (165k inj / 663 det / 7 h-values) with the production pool
- reconcile the factor-~2 mass-channel improvement narrative — measured widths are near-identical across channels (closure carried by golden events)
- p_det KDE description in methods predates the z-resolved survival estimator

Verified by an independent number-check agent: every inserted value traced to the ledger exactly (two findings — SEM rounding and one missing caveat — fixed in this commit); `pdflatex` compiles with 0 errors, no undefined references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG4aVbnNjRbWP3daBufoQX